### PR TITLE
feat(docs) Add description to check if synchronization is complete

### DIFF
--- a/initiation-1/README.md
+++ b/initiation-1/README.md
@@ -56,6 +56,26 @@ $ initiad start
 
 ## How to setup validator
 
+Once synchronization is complete, you can try "Validator Creation". Run the following command and if "catching_up: false" then the synchronization is complete
+
+```sh
+curl http://localhost:26657/status | jq
+
+{
+  "jsonrpc": "2.0",
+  "id": -1,
+  "result": {
+    ...
+    "sync_info": {
+      ...
+      "earliest_block_time": "2024-05-10T07:00:00Z",
+      "catching_up": false # true if not complete
+    },
+    ...
+  }
+}
+```
+
 ### Validator Creation
 
 ```sh


### PR DESCRIPTION
## reason
Knowing that registration is not possible until synchronization is completed, it is better to have it in the document to facilitate the registration of validators and reduce the communication of the same.

## change
Added explanation that synchronization must be completed before validator registration and how to check synchronization status.